### PR TITLE
add Debug to color structs

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -5,15 +5,15 @@ use std::ops;
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[derive(PartialEq, Copy, Clone, Default)]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 /// Represents an R/G/B triplet, in the range 0..1 (32-bit float)
-pub struct RGB {
+pub struct RGB {No reason not to
     pub r: f32,
     pub g: f32,
     pub b: f32,
 }
 
-#[derive(PartialEq, Copy, Clone, Default)]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 /// Represents an H/S/V triplet, in the range 0..1 (32-bit float)
 pub struct HSV {
     pub h: f32,


### PR DESCRIPTION
Need this for my own debugging purposes, and I'm sure this tiny change would be helpful to others in formatting objects containing RGB items