### PR TITLE
HTML buttons support in WASM [WIP]

### DIFF
--- a/src/rltk.rs
+++ b/src/rltk.rs
@@ -1,7 +1,7 @@
 use super::GameState;
 use super::{
     font, framebuffer::Framebuffer, platform_specific, rex::XpFile, rex::XpLayer, Console, Shader,
-    SimpleConsole, VirtualKeyCode, RGB,
+    SimpleConsole, VirtualKeyCode, RGB, platform_specific::Command
 };
 
 /// A display console, used internally to provide console render support.
@@ -29,6 +29,7 @@ pub struct Rltk {
     pub shift: bool,
     pub control: bool,
     pub alt: bool,
+    pub command: Option<platform_specific::Command>,
     pub context_wrapper: Option<platform_specific::WrappedContext>,
     pub quitting: bool,
     pub backing_buffer: Framebuffer,


### PR DESCRIPTION
There are several TODOs scattered across the code, in order of importance:
1) the whole setup part should be done on the game side, not library side (people can have differing HTML buttons and functions, obviously)
2) the repetitive parts should be condensed, possibly via a macro
3) the whole Command enum should be done on the game side, too, and possibly linked to the HTML button's ID
4) naming. Command is a super generic name because I didn't have a better idea and didn't remember that keys are handled via VirtualKeyCode (I had an action system in mind when coming up with this)