### PR TITLE
Optimize field of view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ specs = { version = "0.15.1", optional = true }
 pancurses = { version = "0.16.1", optional = true }
 amethyst = { version = "0.13", optional = true }
 
+[dev-dependencies]
+criterion = "0.3.0"
+
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 glutin = {version = "0.22.0-alpha3", optional = true }
 rand = "0.7.2"
@@ -58,6 +61,11 @@ rand = { version = "0.7.2", features = ["wasm-bindgen"] }
 
 [build-dependencies]
 gl_generator = "0.14.0"
+
+
+[[bench]]
+name = "fov_benchmark"
+harness = false
 
 
 [[example]]

--- a/benches/fov_benchmark.rs
+++ b/benches/fov_benchmark.rs
@@ -1,0 +1,119 @@
+#![allow(unused_variables)]
+
+// Benchmark field of view calculations,
+// most of the code copied from ex04-fov.rs
+
+extern crate rand;
+use crate::rand::Rng;
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{
+    black_box,
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
+
+use rltk::{
+    Algorithm2D,
+    BaseMap,
+    Point,
+};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("all fov 8", |b| b.iter(|| {
+        let s = State::new();
+        let mut i = 0;
+        for x in 0 .. W-1 {
+            for y in 0 .. H-1 {
+                i += 1;
+                if i % 10 != 0 { continue; }
+                let p = Point::new(x, y);
+                let fov = rltk::field_of_view(p, 8, &s);
+                black_box(fov);
+            }
+        }
+    }));
+    c.bench_function("all fov 20", |b| b.iter(|| {
+        let s = State::new();
+        let mut i = 0;
+        for x in 0 .. W-1 {
+            for y in 0 .. H-1 {
+                i += 1;
+                if i % 10 != 0 { continue; }
+                let p = Point::new(x, y);
+                let fov = rltk::field_of_view(p, 20, &s);
+                black_box(fov);
+            }
+        }
+    }));
+}
+
+#[derive(PartialEq, Copy, Clone)]
+enum TileType {
+    Wall,
+    Floor,
+}
+
+struct State {
+    map: Vec<TileType>,
+}
+
+const H:i32 = 50;
+const W:i32 = 80;
+
+fn xy_idx(x: i32, y: i32) -> usize {
+    ((y * W) + x) as usize
+}
+
+fn idx_xy(idx: usize) -> (i32, i32) {
+    (idx as i32 % W, idx as i32 / W)
+}
+
+impl BaseMap for State {
+    fn is_opaque(&self, idx: i32) -> bool {
+        self.map[idx as usize] == TileType::Wall
+    }
+    fn get_available_exits(&self, _idx: i32) -> Vec<(i32, f32)> {
+        Vec::new()
+    }
+    fn get_pathing_distance(&self, _idx1: i32, _idx2: i32) -> f32 {
+        0.0
+    }
+}
+
+impl Algorithm2D for State {
+    fn point2d_to_index(&self, pt: Point) -> i32 {
+        xy_idx(pt.x, pt.y) as i32
+    }
+    fn index_to_point2d(&self, idx: i32) -> Point {
+        Point::new(idx % W, idx / W)
+    }
+    fn in_bounds(&self, pos:Point) -> bool {
+        let idx = self.point2d_to_index(pos);
+        !(idx < 0 || idx >= W-1 * H-1)
+    }
+}
+
+impl State {
+    pub fn new() -> Self {
+        let mut state = State {
+            map: vec![TileType::Floor; (W * H) as usize],
+        };
+
+        let mut rng = rand::thread_rng();
+        for _ in 0..400 {
+            let x = rng.gen_range(1, W-1);
+            let y = rng.gen_range(1, H-1);
+            let idx = xy_idx(x, y);
+            state.map[idx] = TileType::Wall;
+        }
+
+        state
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/fieldofview.rs
+++ b/src/fieldofview.rs
@@ -24,7 +24,7 @@ pub fn field_of_view(start: Point, range: i32, fov_check: &dyn Algorithm2D) -> V
         scan_fov_line(start, Point::new(right, y), range_squared, fov_check, &mut visible_points);
     }
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(visible_points.len());
     for p in visible_points.iter() {
         result.push(*p);
     }


### PR DESCRIPTION
Adds a benchmark for FOV calculation and introduces some optimizations. See commit messages for opt details.

Each optimization step has been benchmarked to ensure it's actually an improvement.

Total improvement is about ~14x for FOV with range 8, and about 27x improvement for FOV with range 20.

Note: The benchmark creates a new random map for each iteration, instead of using a static map. This causes some 5-7% variance in runtimes between benchmark iterations. This should be fixed if we want to do further optimization, since the low hanging fruit is probably all gone now.