### PR TITLE
Breaking change: Make Rltk::shift/ctrl/alt modifiers sticky

### DIFF
--- a/src/hal/native/mainloop.rs
+++ b/src/hal/native/mainloop.rs
@@ -1,7 +1,7 @@
 use super::super::super::{Console, GameState, Rltk};
 use super::super::*;
 use glow::HasContext;
-use glutin::{event::Event, event::WindowEvent, event_loop::ControlFlow};
+use glutin::{event::DeviceEvent, event::Event, event::WindowEvent, event_loop::ControlFlow};
 use std::time::Instant;
 
 const TICK_TYPE: ControlFlow = ControlFlow::Poll;
@@ -39,9 +39,6 @@ pub fn main_loop<GS: GameState>(mut rltk: Rltk, mut gamestate: GS) {
             Event::NewEvents(_) => {
                 rltk.left_click = false;
                 rltk.key = None;
-                rltk.shift = false;
-                rltk.control = false;
-                rltk.alt = false;
             }
             Event::MainEventsCleared => {
                 tock(
@@ -53,6 +50,14 @@ pub fn main_loop<GS: GameState>(mut rltk: Rltk, mut gamestate: GS) {
                     &now,
                 );
                 wc.swap_buffers().unwrap();
+            }
+            Event::DeviceEvent {
+                event: DeviceEvent::ModifiersChanged(modifiers),
+                ..
+            } => {
+                rltk.shift = modifiers.shift();
+                rltk.alt = modifiers.alt();
+                rltk.control = modifiers.ctrl();
             }
             Event::LoopDestroyed => (),
             Event::WindowEvent { ref event, .. } => match event {
@@ -94,21 +99,11 @@ pub fn main_loop<GS: GameState>(mut rltk: Rltk, mut gamestate: GS) {
                         glutin::event::KeyboardInput {
                             virtual_keycode: Some(virtual_keycode),
                             state: glutin::event::ElementState::Pressed,
-                            modifiers,
                             ..
                         },
                     ..
                 } => {
                     rltk.key = Some(*virtual_keycode);
-                    if modifiers.shift() {
-                        rltk.shift = true;
-                    }
-                    if modifiers.alt() {
-                        rltk.alt = true;
-                    }
-                    if modifiers.ctrl() {
-                        rltk.control = true;
-                    }
                 }
 
                 _ => (),


### PR DESCRIPTION
Also removes the use of the deprecated modifiers field in event::KeyboardInput

With this change shift/ctrl/alt will remain true until the modifier keys are depressed. If one wants to only act when the modifier is pressed, one can chose to act only when Rltk::key is VirtualKeyCode::SHIFT_L etc or simply only check shift/ctrl/alt whe Rltk::key is Some(_).