### PR TITLE
fix ecs feature build failure

### DIFF
--- a/src/geometry/point3.rs
+++ b/src/geometry/point3.rs
@@ -14,7 +14,7 @@ pub struct Point3 {
 }
 
 #[cfg(feature = "ecs")]
-impl specs::prelude::Component for Point {
+impl specs::prelude::Component for Point3 {
     type Storage = specs::prelude::VecStorage<Self>;
 }
 

--- a/src/geometry/rect.rs
+++ b/src/geometry/rect.rs
@@ -16,7 +16,7 @@ pub struct Rect {
 }
 
 #[cfg(feature = "ecs")]
-impl specs::prelude::Component for Point {
+impl specs::prelude::Component for Rect {
     type Storage = specs::prelude::VecStorage<Self>;
 }
 


### PR DESCRIPTION
There are three `impl specs::prelude::Component for Point`.
It occurs some build errors with feature `ecs`.
This PR fix above build errors.