### PR TITLE
Fit to api guideline: rename serialization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ exclude = [
 
 [features]
 default = [ "opengl", "parsing" ]
-serialization = [ "serde/derive" ]
 threaded = ["rayon"]
 opengl = [ "glow", "image", "glutin" ]
 ecs = [ "specs" ]
@@ -33,7 +32,7 @@ parsing = [ "regex" ]
 glow = { version = "0.3.0-alpha2", optional = true }
 image = { version = "0.22.3", default-features = false, features = ["jpeg", "png_codec"], optional = true }
 rand_xorshift = "0.2.0"
-serde= { version = "1.0.103", features = ["derive"], optional = true }
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 flate2 = "1.0.13"
 byteorder = "1.3.2"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 
 [features]
 default = [ "opengl", "parsing" ]
-serialization = [ "serde/derive", "serde_json" ]
+serialization = [ "serde/derive" ]
 threaded = ["rayon"]
 opengl = [ "glow", "image", "glutin" ]
 ecs = [ "specs" ]
@@ -34,7 +34,6 @@ glow = { version = "0.3.0-alpha2", optional = true }
 image = { version = "0.22.3", default-features = false, features = ["jpeg", "png_codec"], optional = true }
 rand_xorshift = "0.2.0"
 serde= { version = "1.0.103", features = ["derive"], optional = true }
-serde_json =  { version = "1.0.44", optional = true }
 flate2 = "1.0.13"
 byteorder = "1.3.2"
 lazy_static = "1.4.0"

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,7 +2,7 @@ use super::rex::XpColor;
 use std::ops;
 
 #[cfg_attr(
-    feature = "serialization",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[derive(PartialEq, Copy, Clone, Default, Debug)]

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::ops;
 
 #[cfg_attr(
-    feature = "serialization",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]

--- a/src/geometry/point3.rs
+++ b/src/geometry/point3.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::ops;
 
 #[cfg_attr(
-    feature = "serialization",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]

--- a/src/geometry/rect.rs
+++ b/src/geometry/rect.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use std::ops;
 
 #[cfg_attr(
-    feature = "serialization",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]


### PR DESCRIPTION
In Rust Library Team's API guideline (It is semi-standard),
To get good interoperability,
we need to use serialization feature as name as `serde`.

see also:
  https://rust-lang.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde

and, more small thing, `serde_json` didn't used in rltk_rs.
Maybe, this crate should use in user code, not rltk_rs.
And renaming `serialization` feature is little bit hard if the `serde_json` dependency be. So I dropped the dependency.

Discuss:
Maybe, currently, I guess, there're no active user about `serialization` feature.
Because,  the code had broken before #50 is merge.
So I think, It is a chance to fix this issue.