### PR TITLE
Bresenham circle without diagonal jumping

### DIFF
--- a/src/geometry/circle_bresenham.rs
+++ b/src/geometry/circle_bresenham.rs
@@ -65,9 +65,68 @@ impl Iterator for BresenhamCircle {
     }
 }
 
+/// A version of the Bresenham circle that does not make diagonal jumps
+pub struct BresenhamCircleNoDiag {
+    x: i32,
+    y: i32,
+    center: Point,
+    // radius: i32,
+    error: i32,
+    quadrant: u8,
+}
+
+impl BresenhamCircleNoDiag {
+    #[inline]
+    #[allow(dead_code)]
+    pub fn new(center: Point, radius: i32) -> Self {
+        Self {
+            center,
+            x: -radius,
+            y: 0,
+            error: 0,
+            quadrant: 1,
+        }
+    }
+}
+
+impl Iterator for BresenhamCircleNoDiag {
+    type Item = Point;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.x < 0 {
+            let point = match self.quadrant {
+                1 => (self.center.x - self.x, self.center.y + self.y),
+                2 => (self.center.x - self.y, self.center.y - self.x),
+                3 => (self.center.x + self.x, self.center.y - self.y),
+                4 => (self.center.x + self.y, self.center.y + self.x),
+                _ => unreachable!(),
+            };
+
+            // Update the variables after each set of quadrants.
+            if self.quadrant == 4 {
+                // This version moves in x or in y - not both - depending on the error.
+                if (self.error + 2 * self.x + 1).abs() <= (self.error + 2 * self.y + 1).abs() {
+                    self.error += self.x * 2 + 1;
+                    self.x += 1;
+                } else {
+                    self.error += self.y * 2 + 1;
+                    self.y += 1;
+                }
+            }
+
+            self.quadrant = self.quadrant % 4 + 1;
+
+            Some(Point::from_tuple(point))
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{BresenhamCircle, Point};
+    use super::{BresenhamCircle, BresenhamCircleNoDiag, Point};
 
     #[test]
     fn circle_test_radius1() {
@@ -103,6 +162,41 @@ mod tests {
                 Point { x: -2, y: 2 },
                 Point { x: -2, y: -2 },
                 Point { x: 2, y: -2 },
+                Point { x: 1, y: 3 },
+                Point { x: -3, y: 1 },
+                Point { x: -1, y: -3 },
+                Point { x: 3, y: -1 }
+            ]
+        );
+    }
+
+    #[test]
+    fn circle_nodiag_test_radius3() {
+        let circle = BresenhamCircleNoDiag::new(Point::new(0, 0), 3);
+        let points: Vec<Point> = circle.collect();
+        assert_eq!(
+            points,
+            vec![
+                Point { x: 3, y: 0 },
+                Point { x: 0, y: 3 },
+                Point { x: -3, y: 0 },
+                Point { x: 0, y: -3 },
+                Point { x: 3, y: 1 },
+                Point { x: -1, y: 3 },
+                Point { x: -3, y: -1 },
+                Point { x: 1, y: -3 },
+                Point { x: 2, y: 1 },
+                Point { x: -1, y: 2 },
+                Point { x: -2, y: -1 },
+                Point { x: 1, y: -2 },
+                Point { x: 2, y: 2 },
+                Point { x: -2, y: 2 },
+                Point { x: -2, y: -2 },
+                Point { x: 2, y: -2 },
+                Point { x: 1, y: 2 },
+                Point { x: -2, y: 1 },
+                Point { x: -1, y: -2 },
+                Point { x: 2, y: -1 },
                 Point { x: 1, y: 3 },
                 Point { x: -3, y: 1 },
                 Point { x: -1, y: -3 },

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -8,7 +8,7 @@ mod line_vector;
 pub use line_bresenham::Bresenham;
 pub use line_vector::VectorLine;
 mod circle_bresenham;
-pub use circle_bresenham::BresenhamCircle;
+pub use circle_bresenham::{BresenhamCircle, BresenhamCircleNoDiag};
 mod rect;
 pub use rect::Rect;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub use self::fastnoise::*;
 pub use self::fieldofview::{field_of_view, field_of_view_set};
 pub use self::font::Font;
 pub use self::geometry::{
-    line2d, project_angle, Bresenham, BresenhamCircle, DistanceAlg, LineAlg, Point, Point3, Rect,
-    VectorLine,
+    line2d, project_angle, Bresenham, BresenhamCircle, BresenhamCircleNoDiag, DistanceAlg, LineAlg,
+    Point, Point3, Rect, VectorLine,
 };
 pub use self::pathfinding::astar::{a_star_search, NavigationPath};
 pub use self::pathfinding::dijkstra::DijkstraMap;


### PR DESCRIPTION
Added a version of the Bresenham circle algorithm that does not jump in x and y simultaneously. Replacing with this algorithm version in the field of view calculation solves an issue where points just inside diagonal jumps in the circle would not be included.