### PR TITLE
Initialization branch merge

### DIFF
--- a/benches/batching_benchmark.rs
+++ b/benches/batching_benchmark.rs
@@ -2,7 +2,7 @@
 
 // Benchmark field of geometry calculations
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     use rltk::prelude::*;

--- a/examples/ex01-helloworld.rs
+++ b/examples/ex01-helloworld.rs
@@ -88,6 +88,7 @@ fn main() {
     // with the baked-in 8x8 terminal font.
     let context = RltkBuilder::simple80x50()
         .with_title("Hello RLTK World")
+        .with_vsync(false)
         .build();
 
     // Now we create an empty state object.

--- a/examples/ex01-helloworld.rs
+++ b/examples/ex01-helloworld.rs
@@ -8,7 +8,7 @@ rltk::add_wasm_support!();
 
 // We're using Rltk (the main context) and GameState (a trait defining what our callback
 // looks like), so we need to use that, too.`
-use rltk::{Console, GameState, Rltk, RGB};
+use rltk::prelude::*;
 
 // This is the structure that will store our game state, typically a state machine pointing to
 // other structures. This demo is realy simple, so we'll just put the minimum to make it work
@@ -83,13 +83,12 @@ impl GameState for State {
 
 // Every program needs a main() function!
 fn main() {
-    // RLTK provides a simple initializer for a simple 8x8 font window of a given number of
-    // characters. Since that's all we need here, we'll use it!
-    // We're specifying that we want an 80x50 console, with a title, and a relative path
-    // to where it can find the font files and shader files.
-    // These would normally be "resources" rather than "../../resources" - but to make it
-    // work in the repo without duplicating, they are a relative path.
-    let context = Rltk::init_simple8x8(80, 50, "Hello RLTK World", "resources");
+    // RLTK's ConsoleBuilder interface offers a number of helpers to get you up and running quickly.
+    // Here, we are using the `simple80x50()` helper, which builds an 80-wide by 50-tall console,
+    // with the baked-in 8x8 terminal font.
+    let context = RltkBuilder::simple80x50()
+        .with_title("Hello RLTK World")
+        .build();
 
     // Now we create an empty state object.
     let gs: State = State {

--- a/examples/ex01-helloworld.rs
+++ b/examples/ex01-helloworld.rs
@@ -88,7 +88,6 @@ fn main() {
     // with the baked-in 8x8 terminal font.
     let context = RltkBuilder::simple80x50()
         .with_title("Hello RLTK World")
-        .with_vsync(false)
         .build();
 
     // Now we create an empty state object.

--- a/examples/ex02-sparse.rs
+++ b/examples/ex02-sparse.rs
@@ -92,6 +92,8 @@ fn main() {
         .with_font("vga8x16.png", 8, 16)
         // Next we want a "sparse" (no background) console, of half the height since its an 8x16 font.
         .with_sparse_console(80, 25, "vga8x16.png")
+        // And a window title
+        .with_title("RLTK Example 2 - Sparse Consoles")
         // And call the build function to actually obtain the context.
         .build();
 

--- a/examples/ex02-sparse.rs
+++ b/examples/ex02-sparse.rs
@@ -85,23 +85,15 @@ impl GameState for State {
 
 // Every program needs a main() function!
 fn main() {
-    // RLTK provides a simple initializer for a simple 8x8 font window of a given number of
-    // characters. Since that's all we need here, we'll use it!
-    // We're specifying that we want an 80x50 console, with a title, and a relative path
-    // to where it can find the font files and shader files.
-    // These would normally be "resources" rather than "../../resources" - but to make it
-    // work in the repo without duplicating, they are a relative path.
-    let mut context = Rltk::init_simple8x8(80, 50, "Hello RLTK World", "resources");
-
-    // We want to add a second layer, using an 8x16 VGA font. It looks nicer, and shows how
-    // RLTK can have layers.
-    //
-    // We start by loading the font.
-    let font = context.register_font(rltk::Font::load("resources/vga8x16.png", (8, 16)));
-
-    // Then we initialize it; notice 80x25 (half the height, since 8x16 is twice as tall).
-    // This actually returns the console number, but it's always going to be 1.
-    context.register_console(rltk::SparseConsole::init(80, 25, &context.backend), font);
+    // We're using the RLTK "builder" system to define what we want. We start with a simple
+    // 80x50 background layer.
+    let context = RltkBuilder::simple80x50()
+        // Then we register the 8x16 VGA font. This is embedded automatically, so you can just use it.
+        .with_font("vga8x16.png", 8, 16)
+        // Next we want a "sparse" (no background) console, of half the height since its an 8x16 font.
+        .with_sparse_console(80, 25, "vga8x16.png")
+        // And call the build function to actually obtain the context.
+        .build();
 
     // Now we create an empty state object.
     let gs = State {

--- a/examples/ex03-walking.rs
+++ b/examples/ex03-walking.rs
@@ -172,7 +172,7 @@ impl GameState for State {
 
 fn main() {
     let context = RltkBuilder::simple80x50()
-        .with_title("Hello RLTK World")
+        .with_title("RLTK Example 3 - Walking")
         .build();
     let gs = State::new();
     rltk::main_loop(context, gs);

--- a/examples/ex03-walking.rs
+++ b/examples/ex03-walking.rs
@@ -6,7 +6,7 @@
 //////////////////////////////////////////////////////////////
 
 rltk::add_wasm_support!();
-use rltk::{Console, GameState, Rltk, VirtualKeyCode, RGB};
+use rltk::prelude::*;
 
 // We'll allow map tiles to be either a wall or a floor. We're deriving PartialEq so we don't
 // have to match on it every time. We'll make it a copy type because it's really just an int.
@@ -171,7 +171,9 @@ impl GameState for State {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x8(80, 50, "RLTK Example 03 - Walking Around", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("Hello RLTK World")
+        .build();
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex04-fov.rs
+++ b/examples/ex04-fov.rs
@@ -5,7 +5,7 @@
 //////////////////////////////////////////////////////////////
 
 rltk::add_wasm_support!();
-use rltk::{Algorithm2D, BaseMap, Console, GameState, Point, Rltk, VirtualKeyCode, RGB};
+use rltk::prelude::*;
 
 extern crate rand;
 use crate::rand::Rng;
@@ -178,7 +178,9 @@ impl Algorithm2D for State {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x8(80, 50, "RLTK Example 04 - FOV", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("Hello RLTK World")
+        .build();
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex04-fov.rs
+++ b/examples/ex04-fov.rs
@@ -179,7 +179,7 @@ impl Algorithm2D for State {
 
 fn main() {
     let context = RltkBuilder::simple80x50()
-        .with_title("Hello RLTK World")
+        .with_title("RLTK Example 4 - Field-Of-View")
         .build();
     let gs = State::new();
     rltk::main_loop(context, gs);

--- a/examples/ex05-dijkstra.rs
+++ b/examples/ex05-dijkstra.rs
@@ -285,7 +285,7 @@ impl Algorithm2D for Map {
 
 fn main() {
     let context = RltkBuilder::simple80x50()
-        .with_title("Hello RLTK World")
+        .with_title("RLTK Example 5 - Dijkstra")
         .build();
     let gs = State::new();
     rltk::main_loop(context, gs);

--- a/examples/ex05-dijkstra.rs
+++ b/examples/ex05-dijkstra.rs
@@ -7,7 +7,7 @@
 // Comments that duplicate previous examples have been removed for brevity.
 //////////////////////////////////////////////////////////////
 
-use rltk::{Algorithm2D, BaseMap, Console, DijkstraMap, DistanceAlg, GameState, Point, Rltk, RGB};
+use rltk::prelude::*;
 rltk::add_wasm_support!();
 
 extern crate rand;
@@ -284,7 +284,9 @@ impl Algorithm2D for Map {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x8(80, 50, "RLTK Example 05 - Dijstra Flow Maps", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("Hello RLTK World")
+        .build();
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex06-astar-mouse.rs
+++ b/examples/ex06-astar-mouse.rs
@@ -246,7 +246,7 @@ impl Algorithm2D for State {
 
 fn main() {
     let context = RltkBuilder::simple80x50()
-        .with_title("Hello RLTK World")
+        .with_title("RLTK Example 6 - A* Mouse")
         .build();
     let gs = State::new();
     rltk::main_loop(context, gs);

--- a/examples/ex06-astar-mouse.rs
+++ b/examples/ex06-astar-mouse.rs
@@ -245,7 +245,9 @@ impl Algorithm2D for State {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x8(80, 50, "RLTK Example 05 - A Star and a Mouse", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("Hello RLTK World")
+        .build();
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex07-tiles.rs
+++ b/examples/ex07-tiles.rs
@@ -205,6 +205,7 @@ fn main() {
         WIDTH as u32 * 16,
         HEIGHT as u32 * 16,
         "RLTK Example 07 - Tiles",
+        true
     );
     let font = context.register_font(rltk::Font::load("resources/example_tiles.png", (16, 16)));
     context.register_console(

--- a/examples/ex07-tiles.rs
+++ b/examples/ex07-tiles.rs
@@ -201,21 +201,26 @@ rltk::embedded_resource!(TILE_FONT, "../resources/example_tiles.png");
 
 fn main() {
     rltk::link_resource!(TILE_FONT, "resources/example_tiles.png");
-    let mut context = Rltk::init_raw(
-        WIDTH as u32 * 16,
-        HEIGHT as u32 * 16,
-        "RLTK Example 07 - Tiles",
-        true
-    );
-    let font = context.register_font(rltk::Font::load("resources/example_tiles.png", (16, 16)));
-    context.register_console(
-        rltk::SimpleConsole::init(WIDTH as u32, HEIGHT as u32, &context.backend),
-        font,
-    );
-    context.register_console(
-        rltk::SparseConsole::init(WIDTH as u32, HEIGHT as u32, &context.backend),
-        font,
-    );
+
+    // This initialization is a bit more complicated than the previous examples. It uses
+    // the "raw" initialization to build a tile-based setup from scatch.
+    // new() starts with basically no useful settings
+    let context = RltkBuilder::new()
+        // We specify the CONSOLE dimensions
+        .with_dimensions(WIDTH, HEIGHT)
+        // We specify the size of the tiles
+        .with_tile_dimensions(16, 16)
+        // We give it a window title
+        .with_title("RLTK Example 07 - Tiles")
+        // We register our embedded "example_tiles.png" as a font.
+        .with_font("example_tiles.png", 16, 16)
+        // We want a base simple console for the terrain background
+        .with_simple_console(WIDTH, HEIGHT, "example_tiles.png")
+        // We also want a sparse console atop it to handle moving the character
+        .with_sparse_console(WIDTH, HEIGHT, "example_tiles.png")
+        // And we call the builder function
+        .build();
+
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex08-rex.rs
+++ b/examples/ex08-rex.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{rex::XpFile, Console, GameState, Rltk, RGB};
+use rltk::{rex::XpFile, Console, GameState, Rltk, RGB, RltkBuilder};
 
 struct State {
     nyan: XpFile,
@@ -34,7 +34,9 @@ fn main() {
     rltk::link_resource!(NYAN_CAT, "../resources/nyan.xp");
     let xp = XpFile::from_resource("../resources/nyan.xp").unwrap();
 
-    let context = Rltk::init_simple8x8(80, 50, "Example 8 - Hello Nyan Cat", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 8 - REX Paint, Hello Nyan Cat")
+        .build();
     let gs: State = State { nyan: xp };
     rltk::main_loop(context, gs);
 }

--- a/examples/ex09-offsets.rs
+++ b/examples/ex09-offsets.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{to_cp437, Console, GameState, Rltk, RGB};
+use rltk::prelude::*;
 
 struct State {}
 
@@ -81,8 +81,10 @@ impl GameState for State {
 }
 
 fn main() {
-    let mut context = Rltk::init_simple8x8(80, 50, "Example 9 - Offset Tiles", "resources");
-    context.register_console_no_bg(rltk::SparseConsole::init(80, 50, &context.backend), 0);
+    let mut context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 9 - Offsets")
+        .with_sparse_console(80, 50, "terminal8x8.png")
+        .build();
 
     // We're going to set the second layer's offset to -0.5 to render between tiles
     context.set_active_console(1);

--- a/examples/ex10-postprocess.rs
+++ b/examples/ex10-postprocess.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{rex::XpFile, Console, GameState, Rltk, VirtualKeyCode, RGB};
+use rltk::{rex::XpFile, Console, GameState, Rltk, VirtualKeyCode, RGB, RltkBuilder};
 
 struct State {
     nyan: XpFile,
@@ -51,8 +51,10 @@ fn main() {
     rltk::link_resource!(NYAN_CAT, "../resources/nyan.xp");
     let xp = XpFile::from_resource("../resources/nyan.xp").unwrap();
 
-    let mut context =
-        Rltk::init_simple8x8(80, 50, "Example 10 - Post Process Effects", "resources");
+    let mut context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 10 - Post-Processing Effects")
+        .build();
+
     context.with_post_scanlines(true);
     let gs: State = State {
         nyan: xp,

--- a/examples/ex11-random.rs
+++ b/examples/ex11-random.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{Console, GameState, RandomNumberGenerator, Rltk, RGB};
+use rltk::prelude::*;
 
 struct State {
     rng: RandomNumberGenerator,
@@ -44,7 +44,9 @@ impl GameState for State {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x16(80, 23, "Example 11 - Random Numbers", "resources");
+    let context = RltkBuilder::vga(80, 23)
+        .with_title("Example 11 - Random Numbers")
+        .build();
     let gs: State = State {
         rng: RandomNumberGenerator::new(),
         n_rolls: 0,

--- a/examples/ex12-simplex.rs
+++ b/examples/ex12-simplex.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{Console, FastNoise, FractalType, GameState, NoiseType, Rltk, RGB};
+use rltk::prelude::*;
 
 struct State {
     colors: Vec<RGB>,
@@ -58,6 +58,8 @@ fn main() {
     };
     gs.rebuild_noise();
 
-    let context = Rltk::init_simple8x8(80, 50, "Example 12 - Perlin Noise", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 12 - Perlin Noise")
+        .build();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex13-textblock.rs
+++ b/examples/ex13-textblock.rs
@@ -1,5 +1,5 @@
 rltk::add_wasm_support!();
-use rltk::{Console, GameState, Rltk, TextBlock, TextBuilder, RGB};
+use rltk::prelude::*;
 
 struct State {}
 
@@ -37,6 +37,8 @@ impl GameState for State {
 fn main() {
     let gs: State = State {};
 
-    let context = Rltk::init_simple8x16(80, 25, "Example 13 - Text Blocks", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 13 - Text Blocks")
+        .build();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex14-dwarfmap.rs
+++ b/examples/ex14-dwarfmap.rs
@@ -5,10 +5,7 @@
 //////////////////////////////////////////////////////////////
 
 rltk::add_wasm_support!();
-use rltk::{
-    Algorithm3D, BaseMap, Console, DistanceAlg, FastNoise, FractalType, GameState, NoiseType,
-    Point3, Rltk, RGB,
-};
+use rltk::prelude::*;
 
 #[derive(PartialEq, Copy, Clone)]
 enum TileType {
@@ -329,12 +326,9 @@ impl Algorithm3D for State {
 }
 
 fn main() {
-    let context = Rltk::init_simple8x8(
-        80,
-        50,
-        "RLTK Example 14 - Dwarf Fortress Map Style",
-        "resources",
-    );
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 14 - Dwarf Fortress Map Style")
+        .build();
     let gs = State::new();
     rltk::main_loop(context, gs);
 }

--- a/examples/ex15-specs.rs
+++ b/examples/ex15-specs.rs
@@ -304,12 +304,9 @@ fn main() {
     }
 
     // Initialize RLTK
-    let context = Rltk::init_simple8x8(
-        80,
-        50,
-        "Example 15 - Bouncing Babies with SPECS",
-        "resources",
-    );
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 15 - Bouncing Babies with Specs")
+        .build();
 
     // Run the game loop
     rltk::main_loop(context, gs);

--- a/examples/ex16-keyboard.rs
+++ b/examples/ex16-keyboard.rs
@@ -7,7 +7,7 @@ rltk::add_wasm_support!();
 
 // We're using Rltk (the main context) and GameState (a trait defining what our callback
 // looks like), so we need to use that, too.`
-use rltk::{Console, GameState, Rltk};
+use rltk::prelude::*;
 
 // This is the structure that will store our game state, typically a state machine pointing to
 // other structures. This demo is realy simple, so we'll just put the minimum to make it work
@@ -53,7 +53,9 @@ fn main() {
     // to where it can find the font files and shader files.
     // These would normally be "resources" rather than "../../resources" - but to make it
     // work in the repo without duplicating, they are a relative path.
-    let context = Rltk::init_simple8x8(80, 50, "Hello RLTK World", "resources");
+    let context = RltkBuilder::simple80x50()
+        .with_title("RLTK Example 16 - Keyboard Input Visualizer")
+        .build();
 
     // Now we create an empty state object.
     let gs: State = State {

--- a/src/hal/amethyst_be/init.rs
+++ b/src/hal/amethyst_be/init.rs
@@ -8,6 +8,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     window_title: S,
+    _vsync: bool
 ) -> crate::Rltk {
     crate::Rltk {
         backend: RltkPlatform {

--- a/src/hal/amethyst_be/init.rs
+++ b/src/hal/amethyst_be/init.rs
@@ -1,4 +1,5 @@
 use super::super::RltkPlatform;
+use super::InitHints;
 
 pub struct PlatformGL {
     pub window_title: String,
@@ -8,7 +9,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     window_title: S,
-    _vsync: bool
+    _platform_hints: InitHints
 ) -> crate::Rltk {
     crate::Rltk {
         backend: RltkPlatform {

--- a/src/hal/amethyst_be/mod.rs
+++ b/src/hal/amethyst_be/mod.rs
@@ -7,3 +7,15 @@ mod mainloop;
 pub use mainloop::*;
 mod dummy;
 pub use dummy::*;
+
+pub struct InitHints {
+    pub vsync : bool,
+}
+
+impl InitHints {
+    pub fn new() -> Self {
+        Self{
+            vsync : true,
+        }
+    }
+}

--- a/src/hal/curses/mod.rs
+++ b/src/hal/curses/mod.rs
@@ -14,6 +14,18 @@ mod sparse_console_backing;
 pub use simple_console_backing::SimpleConsoleBackend;
 pub use sparse_console_backing::SparseConsoleBackend;
 
+pub struct InitHints {
+    pub vsync : bool,
+}
+
+impl InitHints {
+    pub fn new() -> Self {
+        Self{
+            vsync : true,
+        }
+    }
+}
+
 pub struct PlatformGL {
     window: Window,
     color_map: Vec<CursesColor>,
@@ -65,7 +77,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
-    _vsync: bool
+    _platform_hints: InitHints
 ) -> crate::Rltk {
     let window = initscr();
     resize_term(height_pixels as i32 / 8, width_pixels as i32 / 8);

--- a/src/hal/curses/mod.rs
+++ b/src/hal/curses/mod.rs
@@ -65,6 +65,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
+    _vsync: bool
 ) -> crate::Rltk {
     let window = initscr();
     resize_term(height_pixels as i32 / 8, width_pixels as i32 / 8);

--- a/src/hal/dummy/mod.rs
+++ b/src/hal/dummy/mod.rs
@@ -1,8 +1,21 @@
 // Dummy platform to let it compile and do nothing. Only useful if you don't want a graphical backend.
 use crate::{GameState, Rltk};
+use super::InitHints;
 
 mod keycodes;
 pub use keycodes::VirtualKeyCode;
+
+pub struct InitHints {
+    pub vsync : bool,
+}
+
+impl InitHints {
+    pub fn new() -> Self {
+        Self{
+            vsync : true,
+        }
+    }
+}
 
 pub struct PlatformGL {}
 
@@ -30,7 +43,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
-    _vsync: bool
+    _platform_hints: InitHints
 ) -> crate::Rltk {
     crate::Rltk {
         backend: super::RltkPlatform {

--- a/src/hal/dummy/mod.rs
+++ b/src/hal/dummy/mod.rs
@@ -30,6 +30,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
+    _vsync: bool
 ) -> crate::Rltk {
     crate::Rltk {
         backend: super::RltkPlatform {

--- a/src/hal/native/init.rs
+++ b/src/hal/native/init.rs
@@ -1,10 +1,11 @@
 use glutin::{dpi::LogicalSize, event_loop::EventLoop, window::WindowBuilder, ContextBuilder};
+use super::InitHints;
 
 pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     window_title: S,
-    vsync: bool
+    platform_hints: InitHints
 ) -> super::super::super::Rltk {
     use super::super::super::Rltk;
     use super::super::*;
@@ -17,11 +18,11 @@ pub fn init_raw<S: ToString>(
             f64::from(height_pixels),
         ));
     let windowed_context = ContextBuilder::new()
-        .with_gl(glutin::GlRequest::Latest)
-        .with_gl_profile(glutin::GlProfile::Core)
+        .with_gl(platform_hints.gl_version)
+        .with_gl_profile(platform_hints.gl_profile)
         .with_hardware_acceleration(Some(true))
-        .with_vsync(vsync)
-        .with_srgb(true)
+        .with_vsync(platform_hints.vsync)
+        .with_srgb(platform_hints.srgb)
         .build_windowed(wb, &el)
         .unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };

--- a/src/hal/native/init.rs
+++ b/src/hal/native/init.rs
@@ -4,6 +4,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     window_title: S,
+    vsync: bool
 ) -> super::super::super::Rltk {
     use super::super::super::Rltk;
     use super::super::*;
@@ -19,7 +20,7 @@ pub fn init_raw<S: ToString>(
         .with_gl(glutin::GlRequest::Latest)
         .with_gl_profile(glutin::GlProfile::Core)
         .with_hardware_acceleration(Some(true))
-        .with_vsync(true)
+        .with_vsync(vsync)
         .with_srgb(true)
         .build_windowed(wb, &el)
         .unwrap();

--- a/src/hal/native/mod.rs
+++ b/src/hal/native/mod.rs
@@ -23,3 +23,23 @@ pub struct WrappedContext {
     pub el: glutin::event_loop::EventLoop<()>,
     pub wc: glutin::WindowedContext<glutin::PossiblyCurrent>,
 }
+
+pub struct InitHints {
+    pub vsync : bool,
+    pub gl_version : glutin::GlRequest,
+    pub gl_profile : glutin::GlProfile,
+    pub hardware_acceleration : bool,
+    pub srgb : bool
+}
+
+impl InitHints {
+    pub fn new() -> Self {
+        Self{
+            vsync : true,
+            gl_version : glutin::GlRequest::Latest,
+            gl_profile : glutin::GlProfile::Core,
+            hardware_acceleration : true,
+            srgb : true
+        }
+    }
+}

--- a/src/hal/wasm/init.rs
+++ b/src/hal/wasm/init.rs
@@ -2,6 +2,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
+    _vsync: bool
 ) -> super::super::super::Rltk {
     use super::super::super::Rltk;
     use super::super::*;

--- a/src/hal/wasm/init.rs
+++ b/src/hal/wasm/init.rs
@@ -1,8 +1,10 @@
+use super::InitHints;
+
 pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
-    _vsync: bool
+    _platform_hints: InitHints
 ) -> super::super::super::Rltk {
     use super::super::super::Rltk;
     use super::super::*;

--- a/src/hal/wasm/mod.rs
+++ b/src/hal/wasm/mod.rs
@@ -16,6 +16,18 @@ pub use sparse_console_backing::*;
 pub mod font;
 pub mod shader;
 
+pub struct InitHints {
+    pub vsync : bool,
+}
+
+impl InitHints {
+    pub fn new() -> Self {
+        Self{
+            vsync : true,
+        }
+    }
+}
+
 pub struct PlatformGL {
     pub gl: glow::Context,
     pub context_wrapper: Option<WrappedContext>,

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -160,6 +160,16 @@ impl RltkBuilder {
         self
     }
 
+    /// Overrides the default assumption for tile sizes. Needed for a raw initialization.
+    pub fn with_tile_dimensions<T>(mut self, width: T, height: T) -> Self
+    where
+        T: TryInto<u32>,
+    {
+        self.tile_width = width.try_into().ok().unwrap();
+        self.tile_height = height.try_into().ok().unwrap();
+        self
+    }
+
     /// Adds a window title to the RLTK builder.
     pub fn with_title<S: ToString>(mut self, title : S) -> Self {
         self.title = Some(title.to_string());

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -20,7 +20,8 @@ pub struct RltkBuilder {
     fonts : Vec<BuilderFont>,
     consoles : Vec<ConsoleType>,
     tile_width: u32,
-    tile_height: u32
+    tile_height: u32,
+    vsync : bool
 }
 
 impl RltkBuilder {
@@ -33,7 +34,8 @@ impl RltkBuilder {
             fonts : Vec::new(),
             consoles : Vec::new(),
             tile_height: 8,
-            tile_width: 8
+            tile_width: 8,
+            vsync: true
         }
     }
 
@@ -46,7 +48,8 @@ impl RltkBuilder {
             fonts : Vec::new(),
             consoles : Vec::new(),
             tile_height: 8,
-            tile_width: 8
+            tile_width: 8,
+            vsync: true
         };
         cb.fonts.push(
             BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
@@ -72,7 +75,8 @@ impl RltkBuilder {
             fonts : Vec::new(),
             consoles : Vec::new(),
             tile_height: 8,
-            tile_width: 8
+            tile_width: 8,
+            vsync: true
         };
         cb.fonts.push(
             BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
@@ -94,7 +98,8 @@ impl RltkBuilder {
             fonts : Vec::new(),
             consoles : Vec::new(),
             tile_height: 16,
-            tile_width: 8
+            tile_width: 8,
+            vsync: true
         };
         cb.fonts.push(
             BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
@@ -120,7 +125,8 @@ impl RltkBuilder {
             fonts : Vec::new(),
             consoles : Vec::new(),
             tile_height: 16,
-            tile_width: 8
+            tile_width: 8,
+            vsync: true
         };
         cb.fonts.push(
             BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
@@ -193,11 +199,17 @@ impl RltkBuilder {
         self
     }
 
+    pub fn with_vsync(mut self, vsync : bool) -> Self {
+        self.vsync = vsync;
+        self
+    }
+
     pub fn build(self) -> Rltk {
         let mut context = init_raw(
             self.width * self.tile_width,
             self.height * self.tile_height,
-            self.title.unwrap_or("RLTK Window".to_string())
+            self.title.unwrap_or("RLTK Window".to_string()),
+            self.vsync
         );
 
         let mut font_map : HashMap<String, usize> = HashMap::new();

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -26,7 +26,7 @@ pub struct RltkBuilder {
     consoles : Vec<ConsoleType>,
     tile_width: u32,
     tile_height: u32,
-    vsync : bool
+    platform_hints : InitHints
 }
 
 impl RltkBuilder {
@@ -42,7 +42,7 @@ impl RltkBuilder {
             consoles : Vec::new(),
             tile_height: 8,
             tile_width: 8,
-            vsync: true
+            platform_hints : InitHints::new()
         }
     }
 
@@ -57,7 +57,7 @@ impl RltkBuilder {
             consoles : Vec::new(),
             tile_height: 8,
             tile_width: 8,
-            vsync: true
+            platform_hints : InitHints::new()
         };
         cb.fonts.push(
             BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
@@ -85,7 +85,7 @@ impl RltkBuilder {
             consoles : Vec::new(),
             tile_height: 8,
             tile_width: 8,
-            vsync: true
+            platform_hints : InitHints::new()
         };
         cb.fonts.push(
             BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
@@ -109,7 +109,7 @@ impl RltkBuilder {
             consoles : Vec::new(),
             tile_height: 16,
             tile_width: 8,
-            vsync: true
+            platform_hints : InitHints::new()
         };
         cb.fonts.push(
             BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
@@ -137,7 +137,7 @@ impl RltkBuilder {
             consoles : Vec::new(),
             tile_height: 16,
             tile_width: 8,
-            vsync: true
+            platform_hints : InitHints::new()
         };
         cb.fonts.push(
             BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
@@ -230,7 +230,13 @@ impl RltkBuilder {
 
     /// Enables you to override the vsync default for native rendering.
     pub fn with_vsync(mut self, vsync : bool) -> Self {
-        self.vsync = vsync;
+        self.platform_hints.vsync = vsync;
+        self
+    }
+
+    /// Push platform-specific initialization hints to the builder. THIS REMOVES CROSS-PLATFORM COMPATIBILITY
+    pub fn with_platform_specific(mut self, hints : InitHints) -> Self {
+        self.platform_hints = hints;
         self
     }
 
@@ -240,7 +246,7 @@ impl RltkBuilder {
             self.width * self.tile_width,
             self.height * self.tile_height,
             self.title.unwrap_or("RLTK Window".to_string()),
-            self.vsync
+            self.platform_hints
         );
 
         let mut font_map : HashMap<String, usize> = HashMap::new();

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -2,16 +2,21 @@ use std::convert::TryInto;
 use crate::prelude::*;
 use std::collections::HashMap;
 
+/// Internal structure defining a font to be loaded.
 struct BuilderFont {
     path : String,
     dimensions : (u32, u32)
 }
 
+/// Internal enum defining a console to be loaded.
 enum ConsoleType {
     SimpleConsole{ width: u32, height: u32, font: String },
     SparseConsole{ width: u32, height: u32, font: String }
 }
 
+/// Provides a builder mechanism for initializing RLTK. You can chain builders together,
+/// and and with a call to `.build()`. This allows you to provide settings if you want to,
+/// or just use a simple initializer if you are in a hurry.
 pub struct RltkBuilder {
     width: u32,
     height: u32,
@@ -25,6 +30,8 @@ pub struct RltkBuilder {
 }
 
 impl RltkBuilder {
+    /// Provides a new, unconfigured, starting point for an RLTK session. You'll have to
+    /// specify everything manually.
     pub fn new() -> Self {
         RltkBuilder{ 
             width : 80,
@@ -39,6 +46,7 @@ impl RltkBuilder {
         }
     }
 
+    /// Provides an 80x50 console in the baked-in 8x8 terminal font as your starting point.
     pub fn simple80x50() -> Self {
         let mut cb = RltkBuilder{ 
             width : 80,
@@ -62,6 +70,7 @@ impl RltkBuilder {
         cb
     }
 
+    /// Provides an 8x8 terminal font simple console, with the specified dimensions as your starting point.
     pub fn simple<T>(width: T, height: T) -> Self 
     where T: TryInto<u32>
     {
@@ -89,6 +98,7 @@ impl RltkBuilder {
         cb
     }
 
+    /// Provides an 80x50 terminal, in the VGA font as your starting point.
     pub fn vga80x50() -> Self {
         let mut cb = RltkBuilder{ 
             width : 80,
@@ -112,6 +122,7 @@ impl RltkBuilder {
         cb
     }
 
+    /// Provides a VGA-font simple terminal with the specified dimensions as your starting point.
     pub fn vga<T>(width: T, height: T) -> Self 
     where T: TryInto<u32>
     {
@@ -139,6 +150,7 @@ impl RltkBuilder {
         cb
     }
 
+    /// Adds width/height dimensions to the RLTK builder.
     pub fn with_dimensions<T>(mut self, width: T, height: T) -> Self
     where
         T: TryInto<u32>,
@@ -148,16 +160,20 @@ impl RltkBuilder {
         self
     }
 
+    /// Adds a window title to the RLTK builder.
     pub fn with_title<S: ToString>(mut self, title : S) -> Self {
         self.title = Some(title.to_string());
         self
     }
 
+    /// Adds a resource path to the RLTK builder. You only need to specify this if you aren't
+    /// embedding your resources.
     pub fn with_resource_path<S: ToString>(mut self, path: S) -> Self {
         self.resource_path = path.to_string();
         self
     }
 
+    /// Adds a font registration to the RLTK builder.
     pub fn with_font<S: ToString, T>(mut self, font_path: S, width: T, height: T) -> Self
     where T:TryInto<u32>
     {
@@ -168,6 +184,7 @@ impl RltkBuilder {
         self
     }
 
+    /// Adds a simple console layer to the RLTK builder.
     pub fn with_simple_console<S:ToString, T>(mut self, width: T, height: T, font: S) -> Self
     where T : TryInto<u32>
     {
@@ -179,15 +196,17 @@ impl RltkBuilder {
         self
     }
 
+    /// Adds a simple console, hard-coded to the baked-in 8x8 terminal font. This does NOT register the font.
     pub fn with_simple8x8(mut self) -> Self {
         self.consoles.push(ConsoleType::SimpleConsole{
             width : self.width,
             height : self.height,
-            font : "resources/terminal8x8.png".to_string()
+            font : "terminal8x8.png".to_string()
         });
         self
     }
 
+    /// Adds a sparse console layer to the RLTK builder.
     pub fn with_sparse_console<S:ToString, T>(mut self, width: T, height: T, font: S) -> Self
     where T: TryInto<u32>
     {
@@ -199,11 +218,13 @@ impl RltkBuilder {
         self
     }
 
+    /// Enables you to override the vsync default for native rendering.
     pub fn with_vsync(mut self, vsync : bool) -> Self {
         self.vsync = vsync;
         self
     }
 
+    /// Combine all of the builder parameters, and return an RLTK context ready to go.
     pub fn build(self) -> Rltk {
         let mut context = init_raw(
             self.width * self.tile_width,

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -1,0 +1,230 @@
+use std::convert::TryInto;
+use crate::prelude::*;
+use std::collections::HashMap;
+
+struct BuilderFont {
+    path : String,
+    dimensions : (u32, u32)
+}
+
+enum ConsoleType {
+    SimpleConsole{ width: u32, height: u32, font: String },
+    SparseConsole{ width: u32, height: u32, font: String }
+}
+
+pub struct RltkBuilder {
+    width: u32,
+    height: u32,
+    title : Option<String>,
+    resource_path : String,
+    fonts : Vec<BuilderFont>,
+    consoles : Vec<ConsoleType>,
+    tile_width: u32,
+    tile_height: u32
+}
+
+impl RltkBuilder {
+    pub fn new() -> Self {
+        RltkBuilder{ 
+            width : 80,
+            height : 50,
+            title : None,
+            resource_path : "resources".to_string(),
+            fonts : Vec::new(),
+            consoles : Vec::new(),
+            tile_height: 8,
+            tile_width: 8
+        }
+    }
+
+    pub fn simple80x50() -> Self {
+        let mut cb = RltkBuilder{ 
+            width : 80,
+            height : 50,
+            title : None,
+            resource_path : "resources".to_string(),
+            fonts : Vec::new(),
+            consoles : Vec::new(),
+            tile_height: 8,
+            tile_width: 8
+        };
+        cb.fonts.push(
+            BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
+        );
+        cb.consoles.push(ConsoleType::SimpleConsole{
+            width : 80,
+            height : 50,
+            font : "terminal8x8.png".to_string()
+        });
+        cb
+    }
+
+    pub fn simple<T>(width: T, height: T) -> Self 
+    where T: TryInto<u32>
+    {
+        let w : u32 = width.try_into().ok().unwrap();
+        let h : u32 = height.try_into().ok().unwrap();
+        let mut cb = RltkBuilder{ 
+            width : w,
+            height : h,
+            title : None,
+            resource_path : "resources".to_string(),
+            fonts : Vec::new(),
+            consoles : Vec::new(),
+            tile_height: 8,
+            tile_width: 8
+        };
+        cb.fonts.push(
+            BuilderFont{ path: "terminal8x8.png".to_string(), dimensions: (8, 8) }
+        );
+        cb.consoles.push(ConsoleType::SimpleConsole{
+            width : w,
+            height : h,
+            font : "terminal8x8.png".to_string()
+        });
+        cb
+    }
+
+    pub fn vga80x50() -> Self {
+        let mut cb = RltkBuilder{ 
+            width : 80,
+            height : 50,
+            title : None,
+            resource_path : "resources".to_string(),
+            fonts : Vec::new(),
+            consoles : Vec::new(),
+            tile_height: 16,
+            tile_width: 8
+        };
+        cb.fonts.push(
+            BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
+        );
+        cb.consoles.push(ConsoleType::SimpleConsole{
+            width : 80,
+            height : 50,
+            font : "vga8x16.png".to_string()
+        });
+        cb
+    }
+
+    pub fn vga<T>(width: T, height: T) -> Self 
+    where T: TryInto<u32>
+    {
+        let w : u32 = width.try_into().ok().unwrap();
+        let h : u32 = height.try_into().ok().unwrap();
+        let mut cb = RltkBuilder{ 
+            width : w,
+            height : h,
+            title : None,
+            resource_path : "resources".to_string(),
+            fonts : Vec::new(),
+            consoles : Vec::new(),
+            tile_height: 16,
+            tile_width: 8
+        };
+        cb.fonts.push(
+            BuilderFont{ path: "vga8x16.png".to_string(), dimensions: (8, 8) }
+        );
+        cb.consoles.push(ConsoleType::SimpleConsole{
+            width : w,
+            height : h,
+            font : "vga8x16.png".to_string()
+        });
+        cb
+    }
+
+    pub fn with_dimensions<T>(mut self, width: T, height: T) -> Self
+    where
+        T: TryInto<u32>,
+    {
+        self.width = width.try_into().ok().unwrap();
+        self.height = height.try_into().ok().unwrap();
+        self
+    }
+
+    pub fn with_title<S: ToString>(mut self, title : S) -> Self {
+        self.title = Some(title.to_string());
+        self
+    }
+
+    pub fn with_resource_path<S: ToString>(mut self, path: S) -> Self {
+        self.resource_path = path.to_string();
+        self
+    }
+
+    pub fn with_font<S: ToString, T>(mut self, font_path: S, width: T, height: T) -> Self
+    where T:TryInto<u32>
+    {
+        self.fonts.push(BuilderFont{
+            path : font_path.to_string(),
+            dimensions: ( width.try_into().ok().unwrap(), height.try_into().ok().unwrap() )
+        });
+        self
+    }
+
+    pub fn with_simple_console<S:ToString, T>(mut self, width: T, height: T, font: S) -> Self
+    where T : TryInto<u32>
+    {
+        self.consoles.push(ConsoleType::SimpleConsole{
+            width : width.try_into().ok().unwrap(),
+            height : height.try_into().ok().unwrap(),
+            font : font.to_string()
+        });
+        self
+    }
+
+    pub fn with_simple8x8(mut self) -> Self {
+        self.consoles.push(ConsoleType::SimpleConsole{
+            width : self.width,
+            height : self.height,
+            font : "resources/terminal8x8.png".to_string()
+        });
+        self
+    }
+
+    pub fn with_sparse_console<S:ToString, T>(mut self, width: T, height: T, font: S) -> Self
+    where T: TryInto<u32>
+    {
+        self.consoles.push(ConsoleType::SparseConsole{
+            width : width.try_into().ok().unwrap(),
+            height : height.try_into().ok().unwrap(),
+            font : font.to_string()
+        });
+        self
+    }
+
+    pub fn build(self) -> Rltk {
+        let mut context = init_raw(
+            self.width * self.tile_width,
+            self.height * self.tile_height,
+            self.title.unwrap_or("RLTK Window".to_string())
+        );
+
+        let mut font_map : HashMap<String, usize> = HashMap::new();
+        for font in &self.fonts {
+            let font_path = format!("{}/{}", self.resource_path, font.path);
+            let font_id = context.register_font(Font::load(font_path.clone(), font.dimensions));
+            println!("Registered font: {} as {}", font_path, font_id);
+            font_map.insert(font_path, font_id);
+        }
+
+        for console in &self.consoles {
+            match console {
+                ConsoleType::SimpleConsole{width, height, font} => {
+                    let font_path = format!("{}/{}", self.resource_path, font);
+                    println!("Looking for font: {}", font_path);
+                    let font_id = font_map[&font_path];
+                    context.register_console(SimpleConsole::init(*width, *height, &context.backend), font_id);
+                }
+                ConsoleType::SparseConsole{width, height, font} => {
+                    let font_path = format!("{}/{}", self.resource_path, font);
+                    println!("Looking for font: {}", font_path);
+                    let font_id = font_map[&font_path];
+                    context.register_console(SparseConsole::init(*width, *height, &context.backend), font_id);
+                }
+            }
+        }
+
+        context
+    }
+}

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -237,7 +237,6 @@ impl RltkBuilder {
         for font in &self.fonts {
             let font_path = format!("{}/{}", self.resource_path, font.path);
             let font_id = context.register_font(Font::load(font_path.clone(), font.dimensions));
-            println!("Registered font: {} as {}", font_path, font_id);
             font_map.insert(font_path, font_id);
         }
 
@@ -245,13 +244,11 @@ impl RltkBuilder {
             match console {
                 ConsoleType::SimpleConsole{width, height, font} => {
                     let font_path = format!("{}/{}", self.resource_path, font);
-                    println!("Looking for font: {}", font_path);
                     let font_id = font_map[&font_path];
                     context.register_console(SimpleConsole::init(*width, *height, &context.backend), font_id);
                 }
                 ConsoleType::SparseConsole{width, height, font} => {
                     let font_path = format!("{}/{}", self.resource_path, font);
-                    println!("Looking for font: {}", font_path);
                     let font_id = font_map[&font_path];
                     context.register_console(SparseConsole::init(*width, *height, &context.backend), font_id);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub use parsing::{parse_dice_string, DiceParseError, DiceType};
 mod command_buffer;
 pub mod embedding;
 pub use command_buffer::*;
+mod initializer;
+pub use initializer::*;
 
 pub mod prelude {
     pub use crate::*;

--- a/src/rltk.rs
+++ b/src/rltk.rs
@@ -39,13 +39,13 @@ pub struct Rltk {
 
 impl Rltk {
     /// Initializes an OpenGL context and a window, stores the info in the Rltk structure.
-    pub fn init_raw<S: ToString, T>(width_pixels: T, height_pixels: T, window_title: S) -> Rltk
+    pub fn init_raw<S: ToString, T>(width_pixels: T, height_pixels: T, window_title: S, vsync: bool) -> Rltk
     where
         T: TryInto<u32>,
     {
         let w: u32 = width_pixels.try_into().ok().unwrap();
         let h: u32 = height_pixels.try_into().ok().unwrap();
-        init_raw(w, h, window_title)
+        init_raw(w, h, window_title, vsync)
     }
 
     /// Quick initialization for when you just want an 8x8 font terminal
@@ -61,7 +61,7 @@ impl Rltk {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/terminal8x8.png", &path_to_shaders.to_string());
-        let mut context = Rltk::init_raw(w * 8, h * 8, window_title);
+        let mut context = Rltk::init_raw(w * 8, h * 8, window_title, true);
         let font = context.register_font(font::Font::load(&font_path.to_string(), (8, 8)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context
@@ -80,7 +80,7 @@ impl Rltk {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/vga8x16.png", &path_to_shaders.to_string());
-        let mut context = Rltk::init_raw(w * 8, h * 16, window_title);
+        let mut context = Rltk::init_raw(w * 8, h * 16, window_title, true);
         let font = context.register_font(font::Font::load(&font_path.to_string(), (8, 16)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context

--- a/src/rltk.rs
+++ b/src/rltk.rs
@@ -1,7 +1,7 @@
 use super::GameState;
 use super::{
     font, hal::init_raw, rex::XpFile, rex::XpLayer, Console, Point, Rect, RltkPlatform, Shader,
-    SimpleConsole, VirtualKeyCode, RGB,
+    SimpleConsole, VirtualKeyCode, RGB, InitHints
 };
 use std::any::Any;
 use std::convert::TryInto;
@@ -39,13 +39,13 @@ pub struct Rltk {
 
 impl Rltk {
     /// Initializes an OpenGL context and a window, stores the info in the Rltk structure.
-    pub fn init_raw<S: ToString, T>(width_pixels: T, height_pixels: T, window_title: S, vsync: bool) -> Rltk
+    pub fn init_raw<S: ToString, T>(width_pixels: T, height_pixels: T, window_title: S, platform_hints: InitHints) -> Rltk
     where
         T: TryInto<u32>,
     {
         let w: u32 = width_pixels.try_into().ok().unwrap();
         let h: u32 = height_pixels.try_into().ok().unwrap();
-        init_raw(w, h, window_title, vsync)
+        init_raw(w, h, window_title, platform_hints)
     }
 
     /// Quick initialization for when you just want an 8x8 font terminal
@@ -61,7 +61,7 @@ impl Rltk {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/terminal8x8.png", &path_to_shaders.to_string());
-        let mut context = Rltk::init_raw(w * 8, h * 8, window_title, true);
+        let mut context = Rltk::init_raw(w * 8, h * 8, window_title, InitHints::new());
         let font = context.register_font(font::Font::load(&font_path.to_string(), (8, 8)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context
@@ -80,7 +80,7 @@ impl Rltk {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/vga8x16.png", &path_to_shaders.to_string());
-        let mut context = Rltk::init_raw(w * 8, h * 16, window_title, true);
+        let mut context = Rltk::init_raw(w * 8, h * 16, window_title, InitHints::new());
         let font = context.register_font(font::Font::load(&font_path.to_string(), (8, 16)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context


### PR DESCRIPTION
This retains the existing initialization interface, other than a new `platform_hints` option on `init_raw` (which very few things use). It also offers a new builder-based initialization, so you can initialize with the much-easier-to-read:

```rust
let context = RltkBuilder::simple80x50()
        .with_title("Hello RLTK World")
        .build();
```

Or a more complex example:

```rust
let context = RltkBuilder::simple80x50()
        // Then we register the 8x16 VGA font. This is embedded automatically, so you can just use it.
        .with_font("vga8x16.png", 8, 16)
        // Next we want a "sparse" (no background) console, of half the height since its an 8x16 font.
        .with_sparse_console(80, 25, "vga8x16.png")
        // And a window title
        .with_title("RLTK Example 2 - Sparse Consoles")
        // And call the build function to actually obtain the context.
        .build();
```

Or the slightly insane but still readable:

```rust
let context = RltkBuilder::new()
        // We specify the CONSOLE dimensions
        .with_dimensions(WIDTH, HEIGHT)
        // We specify the size of the tiles
        .with_tile_dimensions(16, 16)
        // We give it a window title
        .with_title("RLTK Example 07 - Tiles")
        // We register our embedded "example_tiles.png" as a font.
        .with_font("example_tiles.png", 16, 16)
        // We want a base simple console for the terrain background
        .with_simple_console(WIDTH, HEIGHT, "example_tiles.png")
        // We also want a sparse console atop it to handle moving the character
        .with_sparse_console(WIDTH, HEIGHT, "example_tiles.png")
        // And we call the builder function
        .build();
```