### PR TITLE
fixed A* implementation in bracket-pathfinding

### DIFF
--- a/bracket-pathfinding/src/astar.rs
+++ b/bracket-pathfinding/src/astar.rs
@@ -109,13 +109,13 @@ impl AStar {
         let s = Node {
             idx,
             f: q.g + cost + distance_to_end,
-            g: cost,
+            g: q.g + cost,
         };
 
         // If a node with the same position as successor is in the open list with a lower f, skip add
         let mut should_add = true;
         if let Some(e) = self.parents.get(&idx) {
-            if e.1 < s.g {
+            if e.1 <= s.g {
                 should_add = false;
             }
         }


### PR DESCRIPTION
Previously astar.rs was something like a greedy search.
`.../bracket-pathfinding> cargo run --example astar`
resulting in
![before](https://github.com/user-attachments/assets/7e1fcea0-c613-4e5f-9706-24451d5656ec)

Now it returns
![after](https://github.com/user-attachments/assets/825aff7e-b199-4061-ad2b-79a18c6b885c)
as expected